### PR TITLE
refactor: remove redundant isVanillaServer check from ModpackCard and…

### DIFF
--- a/src/components/Modpacks/Details/ModpackActions.tsx
+++ b/src/components/Modpacks/Details/ModpackActions.tsx
@@ -24,7 +24,6 @@ const ModpackActions: React.FC<ModpackActionsProps> = ({ modpack, state }) => {
   const [showRemoveDialog, setShowRemoveDialog] = useState(false);
   const [isRemoving, setIsRemoving] = useState(false);
 
-  const isVanillaServer = modpack.modloader === 'vanilla' || modpack.modloader === 'paper';
   const requiresModpack = !!modpack.urlModpackZip;
 
   const copyToClipboard = async (text: string) => {

--- a/src/components/Modpacks/ModpackCard.tsx
+++ b/src/components/Modpacks/ModpackCard.tsx
@@ -52,7 +52,6 @@ const ModpackCard: React.FC<ModpackCardProps> = ({ modpack, state, onSelect, ind
     );
   };
 
-  const isVanillaServer = modpack.modloader === 'vanilla' || modpack.modloader === 'paper';
   const requiresModpack = !!modpack.urlModpackZip;
 
   const copyToClipboard = async (text: string) => {


### PR DESCRIPTION
… ModpackActions components

- Eliminate unnecessary isVanillaServer variable from both components to streamline code.
- Maintain existing functionality related to modpack handling and requirements.