### PR TITLE
Audit improvements: perf, robustness, security, tests + CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,46 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, "fix/**", "feat/**"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test-frontend:
+    name: Frontend (lint + vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run test
+
+  test-rust:
+    name: Rust (check + clippy + test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: "src-tauri"
+      - name: Install Linux build deps for Tauri
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf libgtk-3-dev libssl-dev libsoup-3.0-dev
+      - name: cargo check
+        working-directory: src-tauri
+        run: cargo check
+      - name: cargo clippy (warnings only, not failing yet — TODO clean and re-enable -D)
+        working-directory: src-tauri
+        run: cargo clippy
+      - name: cargo test
+        working-directory: src-tauri
+        run: cargo test

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,4 +108,24 @@ src-tauri/src/
 
 Client configured via `VITE_SUPABASE_URL` + `VITE_SUPABASE_ANON_KEY` env vars. Auth uses Supabase sessions stored under key `'luminakraft-auth'` in localStorage.
 
-Tables: `users`, `modpacks`, `modpack_versions`, `modpack_images`, `partners`.
+Tables: `users`, `modpacks`, `modpack_versions`, `modpack_images`, `partners`, `modpack_features`, `modpack_collaborators`, `modpack_stats`, `modpack_reviews`, `download_logs`.
+
+## Pre-commit checklist
+
+**Always run BEFORE committing** (CI runs same on push, but local saves time):
+
+1. `npm run lint` — must pass with 0 warnings
+2. `npm run test` — all vitest tests pass
+3. `cd src-tauri && cargo check && cargo clippy -- -D warnings && cargo test` — all Rust checks + tests pass
+4. If touching launch/install flow: smoke test manually (`npm run tauri:dev-stable`)
+5. If touching DB schema or RLS: apply migration to a Supabase branch first, smoke test, then merge to main
+
+If any of these fail, fix the root cause — do not skip hooks or use `--no-verify`.
+
+## Commit conventions
+
+- Conventional Commits format: `fix:`, `perf:`, `feat:`, `chore:`, `refactor:`, `docs:`
+- Subject ≤ 72 chars
+- Body explains WHY (not WHAT — diff already shows what)
+- **Never** add `Co-Authored-By` or AI/assistant attribution
+- One logical change per commit when possible

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "luminakraft-launcher",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "luminakraft-launcher",
-      "version": "0.1.8",
+      "version": "0.1.9",
       "dependencies": {
         "@headlessui/react": "^2.2.10",
         "@supabase/supabase-js": "^2.105.3",
@@ -135,6 +135,7 @@
       "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -150,6 +151,7 @@
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -264,7 +266,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -313,9 +314,31 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1966,7 +1989,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -2026,7 +2050,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2037,7 +2060,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -2086,7 +2108,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -2415,7 +2436,6 @@
       "integrity": "sha512-3Z9HNFiV0IF1fk0JPiK+7kE1GcaIPefQQIBYur6PM5yFIq6agys3uqP/0t966e1wXfmjbRCHDe7qW236Xjwnag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "4.1.5",
         "fflate": "^0.8.2",
@@ -2453,7 +2473,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2494,6 +2513,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2891,7 +2911,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -3227,8 +3246,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -3427,7 +3445,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3686,7 +3705,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -4517,7 +4535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "typescript": "^5 || ^6"
       },
@@ -5107,7 +5124,6 @@
       "integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.1.11",
         "@asamuzakjp/dom-selector": "^7.1.1",
@@ -5567,6 +5583,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -6102,7 +6119,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -6283,6 +6299,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -6298,6 +6315,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -6375,7 +6393,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
       "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6406,7 +6423,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
       "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6472,7 +6488,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-router": {
       "version": "7.15.0",
@@ -7474,7 +7491,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -7684,7 +7700,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7790,7 +7805,6 @@
       "integrity": "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -7882,7 +7896,6 @@
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.5",
         "@vitest/mocker": "4.1.5",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,7 +36,6 @@ dirs = "6.0"
 chrono = { version = "0.4", features = ["serde"] }
 lyceris = "1.1.3"
 zip = "2.1"
-md5 = "0.7"
 base64 = "0.22"
 tiny_http = "0.12"
 portpicker = "0.1"

--- a/src-tauri/src/filesystem.rs
+++ b/src-tauri/src/filesystem.rs
@@ -141,8 +141,16 @@ pub async fn save_instance_metadata(metadata: &InstanceMetadata) -> Result<()> {
     let metadata_path = instance_dir.join("instance.json");
     let metadata_json = serde_json::to_string_pretty(metadata)?;
 
-    let mut file = fs::File::create(metadata_path)?;
-    file.write_all(metadata_json.as_bytes())?;
+    // Atomic write: write to .tmp then rename. Prevents corrupt JSON if process crashes mid-write.
+    // fs::rename is atomic on POSIX and near-atomic on Windows (NTFS).
+    let tmp_path = metadata_path.with_extension("json.tmp");
+    {
+        let mut file = fs::File::create(&tmp_path)?;
+        file.write_all(metadata_json.as_bytes())?;
+        // Best-effort fsync; ignore error on filesystems that don't support it
+        let _ = file.sync_all();
+    }
+    fs::rename(&tmp_path, &metadata_path)?;
 
     Ok(())
 }

--- a/src-tauri/src/launcher.rs
+++ b/src-tauri/src/launcher.rs
@@ -176,7 +176,10 @@ where
     if !meta_dirs.is_version_installed(&modpack.minecraft_version).await {
         emit_progress("progress.downloadingMinecraft".to_string(), 20.0, "downloading_minecraft".to_string());
         
-        // Infinite retry loop for Minecraft installation (libraries/assets)
+        // Bounded retry loop for Minecraft installation (libraries/assets).
+        // Max 20 attempts (~100s with 5s sleep) prevents indefinite hang on degraded networks.
+        const MAX_NETWORK_RETRIES: u32 = 20;
+        let mut attempt: u32 = 0;
         loop {
             match minecraft::install_minecraft_with_lyceris_progress(&modpack, &settings, meta_dirs.meta_dir.clone(), {
                 let emit_progress = emit_progress.clone();
@@ -189,17 +192,26 @@ where
                 Err(e) => {
                     let error_msg = e.to_string();
                     println!("DEBUG: Minecraft Install error: {:?}", e); // Debug log
-                    
-                    // Check for network error - Infinite Retry
-                    if error_msg.contains("Error de red") || error_msg.contains("TIMEDOUT") || error_msg.contains("unreachable") || error_msg.to_lowercase().contains("offline") 
+
+                    // Check for network error - Bounded retry
+                    if error_msg.contains("Error de red") || error_msg.contains("TIMEDOUT") || error_msg.contains("unreachable") || error_msg.to_lowercase().contains("offline")
                         || error_msg.contains("dns") || error_msg.contains("connection closed") || error_msg.contains("hyper::Error") {
-                         
-                         emit_progress("progress.waitingForNetwork".to_string(), 20.0, "waiting_for_network".to_string());
-                         println!("⚠️ Network error installing Minecraft, waiting for connection...");
-                         tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
-                         continue;
+
+                        attempt += 1;
+                        if attempt >= MAX_NETWORK_RETRIES {
+                            println!("❌ Max network retries ({}) exceeded installing Minecraft", MAX_NETWORK_RETRIES);
+                            return Err(anyhow::anyhow!(
+                                "Network error installing Minecraft after {} attempts: {}",
+                                MAX_NETWORK_RETRIES, error_msg
+                            ));
+                        }
+
+                        emit_progress("progress.waitingForNetwork".to_string(), 20.0, "waiting_for_network".to_string());
+                        println!("⚠️ Network error installing Minecraft (attempt {}/{}), waiting...", attempt, MAX_NETWORK_RETRIES);
+                        tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
+                        continue;
                     }
-                    
+
                     return Err(e); // Fatal error
                 }
             }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -17,6 +17,21 @@ mod parallel_download;
 
 use crate::launcher::launch_modpack_action;
 
+/// Validate modpack_id is safe to use in filesystem paths
+/// Rejects path traversal attempts and separators
+fn validate_modpack_id(modpack_id: &str) -> Result<(), String> {
+    if modpack_id.is_empty()
+        || modpack_id.contains("..")
+        || modpack_id.contains('/')
+        || modpack_id.contains('\\')
+        || modpack_id.contains('\0')
+        || modpack_id.starts_with('.')
+    {
+        return Err(format!("Invalid modpack_id: {}", modpack_id));
+    }
+    Ok(())
+}
+
 /// Helper function for serde default values
 
 
@@ -185,6 +200,7 @@ async fn get_instance_metadata(modpack_id: String) -> Result<Option<String>, Str
 
 #[tauri::command]
 async fn get_cached_modpack_data(modpack_id: String) -> Result<Option<String>, String> {
+    validate_modpack_id(&modpack_id)?;
     let launcher_dir = match dirs::data_dir() {
         Some(dir) => dir.join("LKLauncher"),
         None => return Err("Failed to get app data directory".to_string()),
@@ -210,6 +226,7 @@ async fn update_modpack_cache_json(
     modpack_id: String,
     updates: serde_json::Value,
 ) -> Result<(), String> {
+    validate_modpack_id(&modpack_id)?;
     let launcher_dir = match dirs::data_dir() {
         Some(dir) => dir.join("LKLauncher"),
         None => return Err("Failed to get app data directory".to_string()),
@@ -259,6 +276,7 @@ async fn save_modpack_metadata_json(
     modpack_id: String,
     modpack_json: String
 ) -> Result<(), String> {
+    validate_modpack_id(&modpack_id)?;
     let launcher_dir = match dirs::data_dir() {
         Some(dir) => dir.join("LKLauncher"),
         None => return Err("Failed to get app data directory".to_string()),
@@ -1066,6 +1084,7 @@ async fn remove_modpack(modpack_id: String) -> Result<(), String> {
 
 #[tauri::command]
 async fn open_instance_folder(modpack_id: String) -> Result<(), String> {
+    validate_modpack_id(&modpack_id)?;
     let app_data_dir = dirs::data_dir()
         .ok_or_else(|| "Failed to get app data directory".to_string())?;
     

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -382,6 +382,21 @@ async fn get_local_modpacks() -> Result<String, String> {
     }
 }
 
+/// Returns all instance metadata keyed by modpack id, as a JSON object.
+/// Use this instead of N x get_instance_metadata when loading lists of modpacks
+/// to avoid IPC round-trip storms.
+#[tauri::command]
+async fn get_all_instance_metadata() -> Result<String, String> {
+    match filesystem::list_instances().await {
+        Ok(instances) => {
+            let map: std::collections::HashMap<String, &InstanceMetadata> =
+                instances.iter().map(|m| (m.id.clone(), m)).collect();
+            serde_json::to_string(&map).map_err(|e| format!("Failed to serialize metadata map: {}", e))
+        }
+        Err(e) => Err(format!("Failed to list instances: {}", e)),
+    }
+}
+
 #[tauri::command]
 async fn install_modpack(modpack: Modpack) -> Result<(), String> {
     // Validate modpack before installation
@@ -1546,6 +1561,7 @@ fn main() {
             get_file_as_data_url,
             update_instance_ram_settings,
             get_local_modpacks,
+            get_all_instance_metadata,
             install_modpack,
             install_modpack_with_minecraft,
             install_modpack_with_failed_tracking,
@@ -1604,4 +1620,36 @@ fn main() {
         })
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_modpack_id;
+
+    #[test]
+    fn accepts_safe_ids() {
+        assert!(validate_modpack_id("luminapack").is_ok());
+        assert!(validate_modpack_id("crucismc-2024-spring").is_ok());
+        assert!(validate_modpack_id("550e8400-e29b-41d4-a716-446655440000").is_ok());
+    }
+
+    #[test]
+    fn rejects_path_traversal() {
+        assert!(validate_modpack_id("..").is_err());
+        assert!(validate_modpack_id("../etc").is_err());
+        assert!(validate_modpack_id("foo/../bar").is_err());
+    }
+
+    #[test]
+    fn rejects_separators() {
+        assert!(validate_modpack_id("foo/bar").is_err());
+        assert!(validate_modpack_id("foo\\bar").is_err());
+    }
+
+    #[test]
+    fn rejects_dangerous_prefixes_and_empty() {
+        assert!(validate_modpack_id("").is_err());
+        assert!(validate_modpack_id(".hidden").is_err());
+        assert!(validate_modpack_id("foo\0bar").is_err());
+    }
 }

--- a/src-tauri/src/minecraft.rs
+++ b/src-tauri/src/minecraft.rs
@@ -118,7 +118,10 @@ pub async fn stop_instance_process(instance_id: &str) -> crate::Result<()> {
     
     // Also try to kill via the tracked process (if any)
     let maybe_child_arc = {
-        let map_guard = RUNNING_PROCS.lock().unwrap();
+        let map_guard = RUNNING_PROCS.lock().unwrap_or_else(|e| {
+            eprintln!("⚠️ RUNNING_PROCS mutex poisoned (stop_instance_process), recovering: {}", e);
+            e.into_inner()
+        });
         map_guard.get(instance_id).cloned()
     };
 
@@ -579,11 +582,25 @@ pub async fn launch_minecraft_with_token_refresh(modpack: Modpack, settings: Use
             Err(e) => eprintln!("⚠️ Warning: Minecraft verification failed: {}. Assuming offline and attempting to launch...", e),
         }
     
+        // Guard against double-launch
+        {
+            let guard = RUNNING_PROCS.lock().unwrap_or_else(|e| {
+                eprintln!("⚠️ RUNNING_PROCS mutex poisoned (double-launch check), recovering: {}", e);
+                e.into_inner()
+            });
+            if guard.contains_key(&modpack.id) {
+                return Err(anyhow!("Modpack {} is already running", modpack.id));
+            }
+        }
+
         // Launch Minecraft
         let child = launch(&config, Some(&emitter)).await?;
-        
+
         let child_arc = std::sync::Arc::new(AsyncMutex::new(child));
-        RUNNING_PROCS.lock().unwrap().insert(modpack.id.clone(), child_arc.clone());
+        RUNNING_PROCS.lock().unwrap_or_else(|e| {
+            eprintln!("⚠️ RUNNING_PROCS mutex poisoned (insert), recovering: {}", e);
+            e.into_inner()
+        }).insert(modpack.id.clone(), child_arc.clone());
         let _ = app.emit(&format!("minecraft-started-{}", modpack.id), "started");
 
         // Wait for exit
@@ -595,25 +612,42 @@ pub async fn launch_minecraft_with_token_refresh(modpack: Modpack, settings: Use
                     let mut guard = child_arc.lock().await;
                     let _ = guard.wait().await;
                 }
-                RUNNING_PROCS.lock().unwrap().remove(&id_clone);
+                RUNNING_PROCS.lock().unwrap_or_else(|e| {
+                    eprintln!("⚠️ RUNNING_PROCS mutex poisoned (remove), recovering: {}", e);
+                    e.into_inner()
+                }).remove(&id_clone);
                 let _ = app_clone.emit(&format!("minecraft-exited-{}", id_clone), "exited");
             });
         }
     } else {
         let config = config_builder.build();
-    
+
         // Install/verify Minecraft installation first
         // We wrap this in a customized error handling block to allow offline usage
         match install(&config, Some(&emitter)).await {
             Ok(_) => println!("✅ Minecraft verification passed"),
             Err(e) => eprintln!("⚠️ Warning: Minecraft verification failed: {}. Assuming offline and attempting to launch...", e),
         }
-    
+
+        // Guard against double-launch
+        {
+            let guard = RUNNING_PROCS.lock().unwrap_or_else(|e| {
+                eprintln!("⚠️ RUNNING_PROCS mutex poisoned (double-launch check), recovering: {}", e);
+                e.into_inner()
+            });
+            if guard.contains_key(&modpack.id) {
+                return Err(anyhow!("Modpack {} is already running", modpack.id));
+            }
+        }
+
         // Launch Minecraft
         let child = launch(&config, Some(&emitter)).await?;
-        
+
         let child_arc = std::sync::Arc::new(AsyncMutex::new(child));
-        RUNNING_PROCS.lock().unwrap().insert(modpack.id.clone(), child_arc.clone());
+        RUNNING_PROCS.lock().unwrap_or_else(|e| {
+            eprintln!("⚠️ RUNNING_PROCS mutex poisoned (insert), recovering: {}", e);
+            e.into_inner()
+        }).insert(modpack.id.clone(), child_arc.clone());
         let _ = app.emit(&format!("minecraft-started-{}", modpack.id), "started");
 
         // Wait for exit
@@ -625,7 +659,10 @@ pub async fn launch_minecraft_with_token_refresh(modpack: Modpack, settings: Use
                     let mut guard = child_arc.lock().await;
                     let _ = guard.wait().await;
                 }
-                RUNNING_PROCS.lock().unwrap().remove(&id_clone);
+                RUNNING_PROCS.lock().unwrap_or_else(|e| {
+                    eprintln!("⚠️ RUNNING_PROCS mutex poisoned (remove), recovering: {}", e);
+                    e.into_inner()
+                }).remove(&id_clone);
                 let _ = app_clone.emit(&format!("minecraft-exited-{}", id_clone), "exited");
             });
         }

--- a/src-tauri/src/modpack/curseforge/processor.rs
+++ b/src-tauri/src/modpack/curseforge/processor.rs
@@ -62,8 +62,15 @@ where
         "extracting_modpack".to_string()
     );
     
-    // Extract ZIP to temp directory
-    extract_zip(modpack_zip_path, &temp_dir)?;
+    // Extract ZIP to temp directory in a blocking task (rayon parallelism + sync I/O would
+    // starve the tokio runtime otherwise).
+    {
+        let zip_path = modpack_zip_path.clone();
+        let dest = temp_dir.clone();
+        tokio::task::spawn_blocking(move || extract_zip(&zip_path, &dest))
+            .await
+            .map_err(|e| anyhow!("Extract task panicked: {}", e))??;
+    }
     
     emit_progress(
         "Leyendo información del modpack".to_string(),

--- a/src-tauri/src/modpack/extraction.rs
+++ b/src-tauri/src/modpack/extraction.rs
@@ -58,7 +58,14 @@ pub fn extract_zip(zip_path: &PathBuf, extract_to: &PathBuf) -> Result<()> {
                 match archive.by_index(index) {
                     Ok(mut file) => {
                         let output_path = extract_to.join(&name);
-                        
+
+                        // Defense-in-depth: ensure extracted path stays within target dir
+                        // enclosed_name() already strips `..`, but verify anyway
+                        if !output_path.starts_with(extract_to) {
+                            eprintln!("⚠️ Zip-slip blocked: {} escapes {}", output_path.display(), extract_to.display());
+                            return;
+                        }
+
                         if file.is_dir() {
                             let _ = std::fs::create_dir_all(&output_path);
                         } else {

--- a/src-tauri/src/modpack/integrity.rs
+++ b/src-tauri/src/modpack/integrity.rs
@@ -14,8 +14,17 @@ use serde::{Deserialize, Serialize};
 
 type HmacSha256 = Hmac<Sha256>;
 
-/// Secret key for HMAC signing (embedded in binary, obfuscated)
-/// In production, this should be more complex and possibly derived
+/// Secret key for HMAC signing (embedded in binary).
+///
+/// SECURITY NOTE: This is NOT adversarial-grade anti-cheat. The secret can be extracted
+/// from the binary via `strings`/disassembly, so a determined user can re-sign tampered
+/// integrity data. The purpose here is to:
+///   1. Signal "honest mistake" tampering (accidental file edits get caught)
+///   2. Force a minimum effort threshold for cheaters
+///   3. Combined with server-side ZIP SHA256 check at install time, catch most casual abuse
+///
+/// For real anti-cheat, integrity must be verified server-side (e.g., kicking on join
+/// based on a server-trusted manifest), not client-side.
 const HMAC_SECRET: &[u8] = b"LK_INTEGRITY_v1_8f3k2m9x4p7q1w6e";
 
 /// Integrity data stored in instance metadata

--- a/src-tauri/src/modpack/integrity.rs
+++ b/src-tauri/src/modpack/integrity.rs
@@ -323,6 +323,73 @@ pub fn verify_integrity(
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn sign_hashes_is_deterministic_regardless_of_insertion_order() {
+        let mut a: HashMap<String, String> = HashMap::new();
+        a.insert("mods/a.jar".into(), "hash_a".into());
+        a.insert("mods/b.jar".into(), "hash_b".into());
+        a.insert("resourcepacks/c.zip".into(), "hash_c".into());
+
+        let mut b: HashMap<String, String> = HashMap::new();
+        b.insert("resourcepacks/c.zip".into(), "hash_c".into());
+        b.insert("mods/b.jar".into(), "hash_b".into());
+        b.insert("mods/a.jar".into(), "hash_a".into());
+
+        let sig_a = sign_hashes(&a).unwrap();
+        let sig_b = sign_hashes(&b).unwrap();
+        assert_eq!(sig_a, sig_b, "HMAC must be deterministic given the same content");
+    }
+
+    #[test]
+    fn verify_signature_accepts_correct_signature() {
+        let mut h: HashMap<String, String> = HashMap::new();
+        h.insert("mods/x.jar".into(), "deadbeef".into());
+        let sig = sign_hashes(&h).unwrap();
+        assert!(verify_signature(&h, &sig));
+    }
+
+    #[test]
+    fn verify_signature_rejects_tampered_data() {
+        let mut h: HashMap<String, String> = HashMap::new();
+        h.insert("mods/x.jar".into(), "deadbeef".into());
+        let sig = sign_hashes(&h).unwrap();
+        // Tamper: modify a hash after signing
+        h.insert("mods/x.jar".into(), "cafebabe".into());
+        assert!(!verify_signature(&h, &sig));
+    }
+
+    #[test]
+    fn verify_signature_rejects_invalid_signature_string() {
+        let h: HashMap<String, String> = HashMap::new();
+        assert!(!verify_signature(&h, "not-a-real-hmac"));
+    }
+
+    #[test]
+    fn format_issues_produces_human_strings() {
+        let issues = vec![
+            IntegrityIssue::ModifiedFile {
+                path: "mods/foo.jar".into(),
+                expected: "abc123".into(),
+                actual: "xyz789".into(),
+            },
+            IntegrityIssue::UnauthorizedFile { path: "mods/bar.jar".into() },
+            IntegrityIssue::MissingFile { path: "mods/baz.jar".into() },
+            IntegrityIssue::InvalidSignature,
+        ];
+        let formatted = format_issues(&issues);
+        assert_eq!(formatted.len(), 4);
+        assert!(formatted[0].contains("mods/foo.jar"));
+        assert!(formatted[1].contains("mods/bar.jar"));
+        assert!(formatted[2].contains("mods/baz.jar"));
+        assert!(formatted[3].to_lowercase().contains("integridad") || formatted[3].to_lowercase().contains("integrity"));
+    }
+}
+
 /// Format integrity issues for display
 pub fn format_issues(issues: &[IntegrityIssue]) -> Vec<String> {
     issues.iter().map(|issue| {

--- a/src-tauri/src/modpack/modrinth/downloader.rs
+++ b/src-tauri/src/modpack/modrinth/downloader.rs
@@ -129,7 +129,9 @@ where
                 }
             };
             
-            // Download with retry loop
+            // Download with bounded retry loop (max 5 hash mismatch retries to avoid infinite spin)
+            const MAX_HASH_RETRIES: u32 = 5;
+            let mut hash_retries: u32 = 0;
             loop {
                 match download_file(&download_url, &dest_path).await {
                     Ok(()) => {
@@ -143,7 +145,19 @@ where
                             );
                             break;
                         } else {
-                            println!("⚠️ [Modrinth] Hash mismatch for {}, retrying...", filename);
+                            hash_retries += 1;
+                            if hash_retries >= MAX_HASH_RETRIES {
+                                println!("❌ [Modrinth] Hash mismatch for {} after {} retries, marking as failed", filename, MAX_HASH_RETRIES);
+                                let _ = fs::remove_file(&dest_path);
+                                let failed_info = create_failed_file_info(&file, &filename, Some("SHA1 hash mismatch after retries")).await;
+                                let mut failed = failed_files.lock().await;
+                                failed.push(failed_info);
+                                let completed = completed_count.fetch_add(1, Ordering::Relaxed) + 1;
+                                let mod_progress = start_percentage + (completed as f32 / total_files as f32) * progress_range;
+                                emit(format!("progress.downloadingModsProgress|{}|{}", completed, total_files), mod_progress, "file_download_error".to_string());
+                                break;
+                            }
+                            println!("⚠️ [Modrinth] Hash mismatch for {} (attempt {}/{}), retrying...", filename, hash_retries, MAX_HASH_RETRIES);
                             let _ = fs::remove_file(&dest_path);
                             tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
                             continue;
@@ -151,21 +165,21 @@ where
                     },
                     Err(e) => {
                         let error_msg = e.to_string();
-                        
-                        if error_msg.contains("Error de red") || error_msg.contains("TIMEDOUT") || 
+
+                        if error_msg.contains("Error de red") || error_msg.contains("TIMEDOUT") ||
                            error_msg.contains("unreachable") || error_msg.to_lowercase().contains("offline") ||
                            error_msg.contains("dns") || error_msg.contains("connection closed") {
                             println!("⚠️ [Modrinth] Network error for {}, retrying...", filename);
                             tokio::time::sleep(tokio::time::Duration::from_secs(5)).await;
                             continue;
                         }
-                        
+
                         // Fatal error
                         println!("❌ [Modrinth] Failed to download {}: {}", filename, e);
                         let failed_info = create_failed_file_info(&file, &filename, Some(&error_msg)).await;
                         let mut failed = failed_files.lock().await;
                         failed.push(failed_info);
-                        
+
                         let completed = completed_count.fetch_add(1, Ordering::Relaxed) + 1;
                         let mod_progress = start_percentage + (completed as f32 / total_files as f32) * progress_range;
                         emit(format!("progress.downloadingModsProgress|{}|{}", completed, total_files), mod_progress, "file_download_error".to_string());

--- a/src-tauri/src/modpack/modrinth/processor.rs
+++ b/src-tauri/src/modpack/modrinth/processor.rs
@@ -61,8 +61,14 @@ where
         "extracting_modpack".to_string()
     );
     
-    // Extract ZIP to temp directory
-    extract_zip(modpack_zip_path, &temp_dir)?;
+    // Extract ZIP to temp directory in a blocking task to avoid starving tokio runtime
+    {
+        let zip_path = modpack_zip_path.clone();
+        let dest = temp_dir.clone();
+        tokio::task::spawn_blocking(move || extract_zip(&zip_path, &dest))
+            .await
+            .map_err(|e| anyhow!("Extract task panicked: {}", e))??;
+    }
     
     emit_progress(
         "Leyendo información del modpack Modrinth".to_string(),

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,8 @@
         "center": true,
         "resizable": true,
         "dragDropEnabled": false,
-        "zoomHotkeysEnabled": false
+        "zoomHotkeysEnabled": false,
+        "visible": false
       }
     ],
     "security": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,8 +20,7 @@
         "center": true,
         "resizable": true,
         "dragDropEnabled": false,
-        "zoomHotkeysEnabled": false,
-        "visible": false
+        "zoomHotkeysEnabled": false
       }
     ],
     "security": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, lazy, Suspense } from 'react';
 import { invoke } from '@tauri-apps/api/core';
 import { relaunch, exit } from '@tauri-apps/plugin-process';
 import { LauncherProvider, useLauncher } from './contexts/LauncherContext';
@@ -6,13 +6,14 @@ import { AnimationProvider, useAnimation } from './contexts/AnimationContext';
 import Sidebar from './components/Layout/Sidebar';
 import HomePage from './components/Home/HomePage';
 import ModpacksPage from './components/Modpacks/ModpacksPage';
-import MyModpacksPage from './components/Modpacks/MyModpacksPage';
-import PublishModpackForm from './components/Modpacks/PublishModpackForm';
-import EditModpackForm from './components/Modpacks/EditModpackForm';
-import PublishedModpacksPage from './components/Modpacks/PublishedModpacksPage';
-import SettingsPage from './components/Settings/SettingsPage';
-import AboutPage from './components/About/AboutPage';
-import AccountPage from './components/Account/AccountPage';
+// Lazy-loaded routes (non-home, less frequently visited)
+const MyModpacksPage = lazy(() => import('./components/Modpacks/MyModpacksPage'));
+const PublishModpackForm = lazy(() => import('./components/Modpacks/PublishModpackForm'));
+const EditModpackForm = lazy(() => import('./components/Modpacks/EditModpackForm'));
+const PublishedModpacksPage = lazy(() => import('./components/Modpacks/PublishedModpacksPage'));
+const SettingsPage = lazy(() => import('./components/Settings/SettingsPage'));
+const AboutPage = lazy(() => import('./components/About/AboutPage'));
+const AccountPage = lazy(() => import('./components/Account/AccountPage'));
 import UpdateDialog from './components/UpdateDialog';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import LauncherService from './services/launcherService';
@@ -354,7 +355,13 @@ function AppContent() {
             }`}
           style={{ transitionTimingFunction: 'cubic-bezier(0.2, 0, 0, 1)' }}
         >
-          {renderContent()}
+          <Suspense fallback={
+            <div className="flex h-full items-center justify-center">
+              <RefreshCw className="w-8 h-8 animate-spin text-gray-400" />
+            </div>
+          }>
+            {renderContent()}
+          </Suspense>
         </div>
       </main>
 

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Home, Settings, Info, AlertCircle, Pin, PinOff, FolderOpen, UploadCloud, User, Compass } from 'lucide-react';
 import { useLauncher } from '../../contexts/LauncherContext';
@@ -21,6 +21,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeSection, onSectionChange }) => 
   });
   const [hasUpdate, setHasUpdate] = useState(false);
   const [latestVersion, setLatestVersion] = useState<string>('');
+  const hasCheckedUpdates = useRef(false);
 
   // Minecraft Account Dropdown State
   const [isAccountDropdownOpen, setIsAccountDropdownOpen] = useState(false);
@@ -33,20 +34,18 @@ const Sidebar: React.FC<SidebarProps> = ({ activeSection, onSectionChange }) => 
     }
   }, [isPinned]);
 
-  // Check for updates (respecting experimental updates setting)
+  // Check for updates ONCE on mount. Re-checking on every userSettings change spammed the updater endpoint.
   useEffect(() => {
+    if (hasCheckedUpdates.current) return;
+    hasCheckedUpdates.current = true;
     const checkUpdates = async () => {
       try {
-        // Check if prereleases are enabled
         const enablePrereleases = userSettings?.enablePrereleases ?? false;
 
         const update = await check();
         if (update?.available) {
           const isPrerelease = update.version.includes('alpha') || update.version.includes('beta') || update.version.includes('rc');
 
-          // Only show update notification if:
-          // - It's a stable release, OR
-          // - It's a prerelease AND experimental updates are enabled
           if (!isPrerelease || enablePrereleases) {
             setHasUpdate(true);
             setLatestVersion(update.version);
@@ -57,55 +56,21 @@ const Sidebar: React.FC<SidebarProps> = ({ activeSection, onSectionChange }) => 
       }
     };
     checkUpdates();
-  }, [userSettings?.enablePrereleases]);
+    // Intentionally empty deps — runs once. enablePrereleases read fresh inside the async fn.
+  }, []);
 
   // Version is automatically updated by release.js
   const currentVersion = "0.1.9";
 
-  const menuItems = [
-    {
-      id: 'home',
-      label: t('navigation.home'),
-      icon: Home,
-      description: t('navigation.homeDesc')
-    },
-    {
-      id: 'explore',
-      label: t('navigation.explore'),
-      icon: Compass,
-      description: t('navigation.exploreDesc')
-    },
-    {
-      id: 'my-modpacks',
-      label: t('navigation.myModpacks'),
-      icon: FolderOpen,
-      description: t('navigation.myModpacksDesc')
-    },
-    {
-      id: 'published-modpacks',
-      label: t('navigation.publishedModpacks'),
-      icon: UploadCloud,
-      description: t('navigation.publishedModpacksDesc')
-    },
-    {
-      id: 'account',
-      label: t('navigation.account'),
-      icon: User,
-      description: t('navigation.accountDesc')
-    },
-    {
-      id: 'settings',
-      label: t('navigation.settings'),
-      icon: Settings,
-      description: 'Ajustes del launcher'
-    },
-    {
-      id: 'about',
-      label: t('navigation.about'),
-      icon: Info,
-      description: 'Información del launcher'
-    }
-  ];
+  const menuItems = useMemo(() => [
+    { id: 'home', label: t('navigation.home'), icon: Home, description: t('navigation.homeDesc') },
+    { id: 'explore', label: t('navigation.explore'), icon: Compass, description: t('navigation.exploreDesc') },
+    { id: 'my-modpacks', label: t('navigation.myModpacks'), icon: FolderOpen, description: t('navigation.myModpacksDesc') },
+    { id: 'published-modpacks', label: t('navigation.publishedModpacks'), icon: UploadCloud, description: t('navigation.publishedModpacksDesc') },
+    { id: 'account', label: t('navigation.account'), icon: User, description: t('navigation.accountDesc') },
+    { id: 'settings', label: t('navigation.settings'), icon: Settings, description: 'Ajustes del launcher' },
+    { id: 'about', label: t('navigation.about'), icon: Info, description: 'Información del launcher' }
+  ], [t]);
 
   const handleAvatarClick = () => {
     setIsAccountDropdownOpen(!isAccountDropdownOpen);

--- a/src/components/Modpacks/ModpackCard.tsx
+++ b/src/components/Modpacks/ModpackCard.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, memo } from 'react';
+import React, { useState, useEffect, useMemo, memo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Download, Play, RefreshCw, Wrench, AlertTriangle, Loader2, Globe, Trash2, FolderOpen, StopCircle, Clock, Settings, Info } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
@@ -440,13 +440,15 @@ const ModpackCard: React.FC<ModpackCardProps> = memo(({ modpack, state, onSelect
       : ''
     }`;
 
+  const cardStyle = useMemo(() => ({
+    animation: `fadeInUp 0.15s ease-out ${index * 0.02 + 0.1}s backwards`,
+    ...getAnimationStyle({})
+  }), [index, getAnimationStyle]);
+
   return (
     <div
       className={cardClasses}
-      style={{
-        animation: `fadeInUp 0.15s ease-out ${index * 0.02 + 0.1}s backwards`,
-        ...getAnimationStyle({})
-      }}
+      style={cardStyle}
     >
       {/* Status Badge - Top right corner of entire card */}
       {!hideServerBadges && (

--- a/src/contexts/AnimationContext.tsx
+++ b/src/contexts/AnimationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { createContext, useContext, useCallback, useMemo, ReactNode } from 'react';
 import { useLauncher } from './LauncherContext';
 
 interface AnimationContextType {
@@ -15,12 +15,12 @@ export function AnimationProvider({ children }: { children: ReactNode }) {
   const { userSettings } = useLauncher();
   const animationsEnabled = userSettings.enableAnimations !== false; // default to true
 
-  const getAnimationClass = (baseClass: string, animatedClass: string = '') => {
+  const getAnimationClass = useCallback((baseClass: string, animatedClass: string = '') => {
     if (!animationsEnabled) return baseClass;
     return `${baseClass} ${animatedClass}`.trim();
-  };
+  }, [animationsEnabled]);
 
-  const getAnimationStyle = (style: React.CSSProperties): React.CSSProperties => {
+  const getAnimationStyle = useCallback((style: React.CSSProperties): React.CSSProperties => {
     if (!animationsEnabled) {
       // Completely disable all animations, transitions, and transforms
       const disabledStyle: React.CSSProperties = {
@@ -32,7 +32,7 @@ export function AnimationProvider({ children }: { children: ReactNode }) {
         transitionDuration: '0s !important' as any,
         transitionDelay: '0s !important' as any,
       };
-      
+
       // Remove scale transforms but keep other transforms like translate
       if (style.transform) {
         disabledStyle.transform = style.transform
@@ -40,22 +40,22 @@ export function AnimationProvider({ children }: { children: ReactNode }) {
           .replace(/rotate\([^)]+\)/g, '')
           .trim();
       }
-      
+
       return disabledStyle;
     }
     return style;
-  };
+  }, [animationsEnabled]);
 
   // Get appropriate delay - returns 0 if animations are disabled, original delay if enabled
-  const getDelay = (delay: number): number => {
+  const getDelay = useCallback((delay: number): number => {
     return animationsEnabled ? delay : 0;
-  };
+  }, [animationsEnabled]);
 
   // Execute callback with appropriate delay
-  const withDelay = (callback: () => void, delay: number): void => {
+  const withDelay = useCallback((callback: () => void, delay: number): void => {
     const actualDelay = animationsEnabled ? delay : 0;
     setTimeout(callback, actualDelay);
-  };
+  }, [animationsEnabled]);
 
   // Add global CSS to disable animations when setting is off
   React.useEffect(() => {
@@ -81,14 +81,16 @@ export function AnimationProvider({ children }: { children: ReactNode }) {
     }
   }, [animationsEnabled]);
 
+  const contextValue = useMemo(() => ({
+    animationsEnabled,
+    getAnimationClass,
+    getAnimationStyle,
+    getDelay,
+    withDelay,
+  }), [animationsEnabled, getAnimationClass, getAnimationStyle, getDelay, withDelay]);
+
   return (
-    <AnimationContext.Provider value={{
-      animationsEnabled,
-      getAnimationClass,
-      getAnimationStyle,
-      getDelay,
-      withDelay,
-    }}>
+    <AnimationContext.Provider value={contextValue}>
       {children}
     </AnimationContext.Provider>
   );

--- a/src/contexts/LauncherContext.tsx
+++ b/src/contexts/LauncherContext.tsx
@@ -660,30 +660,33 @@ export function LauncherProvider({ children }: { children: ReactNode }) {
 
     if (!state.modpacksData) return;
 
-    // 2. Load/Update states for server modpacks
-    for (const modpack of state.modpacksData.modpacks) {
-      try {
-        const status = await launcherService.getModpackStatus(modpack.id);
-        dispatch({
-          type: 'SET_MODPACK_STATE',
-          payload: {
-            id: modpack.id,
-            state: createModpackState(status),
-          },
-        });
-      } catch (error) {
-        console.error(`Error loading state for modpack ${modpack.id}:`, error);
-        dispatch({
-          type: 'SET_MODPACK_STATE',
-          payload: {
-            id: modpack.id,
-            state: createModpackState('error', {
-              error: 'Error loading state'
-            }),
-          },
-        });
-      }
-    }
+    // 2. Load/Update states for server modpacks IN PARALLEL.
+    // Previously sequential awaits caused N IPC round-trips back-to-back.
+    await Promise.all(
+      state.modpacksData.modpacks.map(async (modpack) => {
+        try {
+          const status = await launcherService.getModpackStatus(modpack.id);
+          dispatch({
+            type: 'SET_MODPACK_STATE',
+            payload: {
+              id: modpack.id,
+              state: createModpackState(status),
+            },
+          });
+        } catch (error) {
+          console.error(`Error loading state for modpack ${modpack.id}:`, error);
+          dispatch({
+            type: 'SET_MODPACK_STATE',
+            payload: {
+              id: modpack.id,
+              state: createModpackState('error', {
+                error: 'Error loading state'
+              }),
+            },
+          });
+        }
+      })
+    );
   };
 
   const updateUserSettings = async (settings: Partial<UserSettings>) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,3 +5,20 @@ import "./i18n";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App />,
 );
+
+// Show the Tauri window after the first paint to avoid the white flash on startup.
+// The window is created with `visible: false` in tauri.conf.json.
+if (typeof window !== "undefined" && (window as any).__TAURI_INTERNALS__) {
+  // Defer until the browser has rendered at least one frame
+  requestAnimationFrame(() => {
+    requestAnimationFrame(async () => {
+      try {
+        const { getCurrentWindow } = await import("@tauri-apps/api/window");
+        await getCurrentWindow().show();
+        await getCurrentWindow().setFocus();
+      } catch (err) {
+        console.error("Failed to show Tauri window:", err);
+      }
+    });
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,20 +5,3 @@ import "./i18n";
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <App />,
 );
-
-// Show the Tauri window after the first paint to avoid the white flash on startup.
-// The window is created with `visible: false` in tauri.conf.json.
-if (typeof window !== "undefined" && (window as any).__TAURI_INTERNALS__) {
-  // Defer until the browser has rendered at least one frame
-  requestAnimationFrame(() => {
-    requestAnimationFrame(async () => {
-      try {
-        const { getCurrentWindow } = await import("@tauri-apps/api/window");
-        await getCurrentWindow().show();
-        await getCurrentWindow().setFocus();
-      } catch (err) {
-        console.error("Failed to show Tauri window:", err);
-      }
-    });
-  });
-}

--- a/src/services/__tests__/authService.test.ts
+++ b/src/services/__tests__/authService.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Unit tests for AuthService pure logic.
+ *
+ * Scope: Only pure functions / logic extracted from authService.ts.
+ * Network calls (Supabase, Discord API) are fully mocked.
+ * Tauri invoke is mocked so the module can be imported in jsdom.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// --- Mocks (must come before any module imports that transitively load them) ---
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+
+vi.mock('../supabaseClient', () => ({
+  supabase: {
+    auth: {
+      onAuthStateChange: vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } })),
+      getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+      signOut: vi.fn().mockResolvedValue({}),
+      setSession: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    },
+    from: vi.fn(() => ({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    })),
+    functions: {
+      invoke: vi.fn().mockResolvedValue({ data: {}, error: null }),
+    },
+  },
+  updateUser: vi.fn().mockResolvedValue({ error: null }),
+}));
+
+// ============================================================
+// Helpers — pure logic extracted from authService.ts
+// These mirror the exact code in the service so tests remain
+// stable even if the private methods are refactored.
+// ============================================================
+
+/**
+ * Build Discord CDN avatar URL from userId + avatarHash.
+ * Mirrors logic inside AuthService.syncDiscordData().
+ */
+function buildDiscordAvatarUrl(
+  userId: string,
+  avatarHash: string | null
+): string | null {
+  if (!avatarHash) return null;
+  const ext = avatarHash.startsWith('a_') ? 'gif' : 'png';
+  return `https://cdn.discordapp.com/avatars/${userId}/${avatarHash}.${ext}`;
+}
+
+/**
+ * Extract avatar hash from a full CDN URL or return the hash directly.
+ * Mirrors the `avatarHash` extraction block in AuthService.syncDiscordData().
+ */
+function extractAvatarHash(
+  avatarField: string | null | undefined,
+  avatarUrlField: string | null | undefined
+): string | null {
+  if (avatarField) return avatarField;
+  if (avatarUrlField) {
+    const match = avatarUrlField.match(/avatars\/\d+\/([^.?]+)/);
+    return match ? match[1] : null;
+  }
+  return null;
+}
+
+/**
+ * Remove legacy discriminator from a Discord username.
+ * Mirrors the `cleanUsername` logic in AuthService.syncDiscordData().
+ */
+function cleanDiscordUsername(username: string): string {
+  if (username.includes('#')) {
+    return username.split('#')[0];
+  }
+  return username;
+}
+
+/**
+ * Get anonymous username from a parsed settings object.
+ * Mirrors AuthService.getAnonymousUsernameFromLocalStorage().
+ */
+function getAnonymousUsernameFromSettings(
+  settings: Record<string, unknown> | null
+): string | null {
+  if (!settings) return null;
+  return (settings.username as string) || null;
+}
+
+// ============================================================
+// Tests
+// ============================================================
+
+describe('buildDiscordAvatarUrl', () => {
+  it('returns null when avatarHash is null', () => {
+    expect(buildDiscordAvatarUrl('123456789', null)).toBeNull();
+  });
+
+  it('builds a PNG URL for a static hash', () => {
+    const url = buildDiscordAvatarUrl('123456789', 'abc123');
+    expect(url).toBe('https://cdn.discordapp.com/avatars/123456789/abc123.png');
+  });
+
+  it('builds a GIF URL for an animated hash (a_ prefix)', () => {
+    const url = buildDiscordAvatarUrl('123456789', 'a_animatedhash');
+    expect(url).toBe('https://cdn.discordapp.com/avatars/123456789/a_animatedhash.gif');
+  });
+});
+
+describe('extractAvatarHash', () => {
+  it('prefers the direct avatar hash field over URL', () => {
+    const hash = extractAvatarHash('directhash', 'https://cdn.discordapp.com/avatars/111/urlhash.png');
+    expect(hash).toBe('directhash');
+  });
+
+  it('parses hash from a CDN avatar URL when direct field is absent', () => {
+    const hash = extractAvatarHash(null, 'https://cdn.discordapp.com/avatars/123456/abcdef.png');
+    expect(hash).toBe('abcdef');
+  });
+
+  it('parses animated hash (with a_ prefix) from CDN URL', () => {
+    const hash = extractAvatarHash(null, 'https://cdn.discordapp.com/avatars/789/a_animated.gif');
+    expect(hash).toBe('a_animated');
+  });
+
+  it('returns null when both fields are absent', () => {
+    expect(extractAvatarHash(null, null)).toBeNull();
+  });
+
+  it('returns null when URL does not match the expected CDN pattern', () => {
+    expect(extractAvatarHash(null, 'https://example.com/image.png')).toBeNull();
+  });
+});
+
+describe('cleanDiscordUsername', () => {
+  it('strips legacy discriminator from username#0000 format', () => {
+    expect(cleanDiscordUsername('PlayerOne#1234')).toBe('PlayerOne');
+  });
+
+  it('leaves modern usernames (no discriminator) unchanged', () => {
+    expect(cleanDiscordUsername('moderndiscorduser')).toBe('moderndiscorduser');
+  });
+
+  it('handles empty string without throwing', () => {
+    expect(cleanDiscordUsername('')).toBe('');
+  });
+});
+
+describe('getAnonymousUsernameFromSettings', () => {
+  it('returns username from a valid settings object', () => {
+    expect(getAnonymousUsernameFromSettings({ username: 'CoolPlayer' })).toBe('CoolPlayer');
+  });
+
+  it('returns null when settings is null', () => {
+    expect(getAnonymousUsernameFromSettings(null)).toBeNull();
+  });
+
+  it('returns null when username key is missing', () => {
+    expect(getAnonymousUsernameFromSettings({ language: 'en' })).toBeNull();
+  });
+
+  it('returns null when username is an empty string', () => {
+    // empty string is falsy → same as missing
+    expect(getAnonymousUsernameFromSettings({ username: '' })).toBeNull();
+  });
+});
+
+describe('AuthService module import (smoke test)', () => {
+  it('can import AuthService without throwing (all deps mocked)', async () => {
+    // Just verifying the module loads — no network involved
+    const mod = await import('../authService');
+    expect(mod.default).toBeDefined();
+  });
+});

--- a/src/services/__tests__/launcherService.test.ts
+++ b/src/services/__tests__/launcherService.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Unit tests for LauncherService logic that doesn't require Tauri/Supabase.
+ *
+ * We mock everything network-related; this file exercises pure logic:
+ *   - clientToken generation format
+ *   - settings load/save with localStorage
+ *   - RAM migration GB → MB
+ *   - cache helpers (limited to behavior visible through public API)
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn() }));
+vi.mock('@tauri-apps/plugin-fs', () => ({ readFile: vi.fn() }));
+vi.mock('../supabaseClient', () => ({
+  supabase: {
+    from: () => ({
+      select: () => ({ limit: () => Promise.resolve({ error: null }) }),
+    }),
+    auth: { getUser: () => Promise.resolve({ data: { user: null } }) },
+    rpc: () => Promise.resolve({ data: null, error: null }),
+  },
+}));
+vi.mock('./authService', () => ({
+  default: { getInstance: () => ({ getSupabaseAccessToken: () => Promise.resolve(null) }) },
+}));
+
+// localStorage shim — vitest's jsdom env provides one but we want a clean slate per test
+beforeEach(() => {
+  localStorage.clear();
+  // Reset module cache so the singleton re-reads localStorage
+  vi.resetModules();
+});
+
+describe('LauncherService settings load/save', () => {
+  it('generates a clientToken on first load when none exists', async () => {
+    const { default: LauncherService } = await import('../launcherService');
+    const svc = LauncherService.getInstance();
+    const settings = svc.getUserSettings();
+    expect(settings.clientToken).toBeTruthy();
+    // URL-safe base64 — no +, /, or = padding
+    expect(settings.clientToken).toMatch(/^[A-Za-z0-9_-]+$/);
+    // 24 random bytes → 32 chars base64 (no padding)
+    expect(settings.clientToken!.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('persists settings to localStorage on save', async () => {
+    const { default: LauncherService } = await import('../launcherService');
+    const svc = LauncherService.getInstance();
+    svc.saveUserSettings({ username: 'Steve', allocatedRam: 6144 });
+    const saved = JSON.parse(localStorage.getItem('LuminaKraftLauncher_settings')!);
+    expect(saved.username).toBe('Steve');
+    expect(saved.allocatedRam).toBe(6144);
+  });
+
+  it('migrates legacy RAM in GB to MB on load', async () => {
+    // Simulate legacy state: 4 GB stored as `4` (not 4096 MB)
+    localStorage.setItem('LuminaKraftLauncher_settings', JSON.stringify({
+      username: 'Player',
+      allocatedRam: 4,
+      language: 'en',
+      authMethod: 'offline',
+      clientToken: 'preserved-token',
+    }));
+    const { default: LauncherService } = await import('../launcherService');
+    const svc = LauncherService.getInstance();
+    const settings = svc.getUserSettings();
+    expect(settings.allocatedRam).toBe(4096);
+    expect(settings.clientToken).toBe('preserved-token');
+  });
+
+  it('regenerates clientToken if missing in saved settings', async () => {
+    localStorage.setItem('LuminaKraftLauncher_settings', JSON.stringify({
+      username: 'Player',
+      allocatedRam: 4096,
+      language: 'en',
+      authMethod: 'offline',
+      // clientToken intentionally absent
+    }));
+    const { default: LauncherService } = await import('../launcherService');
+    const svc = LauncherService.getInstance();
+    const settings = svc.getUserSettings();
+    expect(settings.clientToken).toBeTruthy();
+    expect(settings.clientToken).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it('clearCache dispatches the luminakraft:cache-cleared event', async () => {
+    const { default: LauncherService } = await import('../launcherService');
+    const svc = LauncherService.getInstance();
+    let fired = false;
+    const handler = () => { fired = true; };
+    window.addEventListener('luminakraft:cache-cleared', handler);
+    svc.clearCache();
+    window.removeEventListener('luminakraft:cache-cleared', handler);
+    expect(fired).toBe(true);
+  });
+});

--- a/src/services/launcherService.ts
+++ b/src/services/launcherService.ts
@@ -622,6 +622,21 @@ class LauncherService {
     }
   }
 
+  /**
+   * Batch fetch of ALL instance metadata in a single IPC call.
+   * Returns a map keyed by modpack id. Avoids N round-trips when loading lists.
+   */
+  async getAllInstanceMetadata(): Promise<Record<string, InstanceMetadata>> {
+    if (!isTauriContext()) return {};
+    try {
+      const json = await safeInvoke<string>('get_all_instance_metadata');
+      return json ? JSON.parse(json) : {};
+    } catch (error) {
+      console.error('Error getting all instance metadata:', error);
+      return {};
+    }
+  }
+
   // Helper function to ensure modpack has required fields, refreshing data if needed
   private async ensureModpackHasRequiredFields(modpackId: string): Promise<any> {
     let modpack = this.modpacksData?.modpacks.find((m: any) => m.id === modpackId);

--- a/src/services/launcherService.ts
+++ b/src/services/launcherService.ts
@@ -300,8 +300,9 @@ class LauncherService {
 
       if (uniqueAuthorIds.length > 0) {
         try {
+          // Use users_public view — public.users no longer permits anon/cross-user reads (RLS).
           const { data: authors } = await supabase
-            .from('users')
+            .from('users_public' as any)
             .select('id, display_name, discord_global_name, discord_username')
             .in('id', uniqueAuthorIds);
 

--- a/src/services/modpackManagementService.ts
+++ b/src/services/modpackManagementService.ts
@@ -186,12 +186,12 @@ export class ModpackManagementService {
         return { hasPermission: false, error: 'User not authenticated' };
       }
 
-      // Get modpack details
+      // Get modpack details (read modpack.partner_id directly — avoid looking up another user's partner_id)
       const { data: modpack, error: modpackError } = await supabase
         .from('modpacks')
-        .select('author_id, category')
+        .select('author_id, category, partner_id')
         .eq('id', modpackId)
-        .single() as { data: { author_id: string; category: string } | null; error: any };
+        .single() as { data: { author_id: string; category: string; partner_id: string | null } | null; error: any };
 
       if (modpackError || !modpack) {
         return { hasPermission: false, error: 'Modpack not found' };
@@ -218,17 +218,11 @@ export class ModpackManagementService {
         return { hasPermission: true };
       }
 
-      // Check if same partner (for partner category modpacks)
-      if (modpack.category === 'partner' && userData.partner_id) {
-        const { data: authorData } = await supabase
-          .from('users')
-          .select('partner_id')
-          .eq('id', modpack.author_id)
-          .single() as { data: { partner_id: string | null } | null };
-
-        if (authorData?.partner_id && authorData.partner_id === userData.partner_id) {
-          return { hasPermission: true };
-        }
+      // Check if same partner (for partner category modpacks).
+      // Compare modpacks.partner_id (already loaded) instead of looking up author's user row,
+      // which is no longer readable by anon/cross-user under tightened RLS.
+      if (modpack.category === 'partner' && userData.partner_id && modpack.partner_id === userData.partner_id) {
+        return { hasPermission: true };
       }
 
       return { hasPermission: false, error: 'Insufficient permissions' };
@@ -1149,12 +1143,14 @@ export class ModpackManagementService {
 
       // Get modpack details to verify ownership and get file paths
       // Note: file_url is in modpack_versions, not modpacks table
+      // partner_id read directly to avoid looking up another user's profile (RLS-restricted)
       const { data: modpack, error: modpackError } = await supabase
         .from('modpacks')
         .select(`
           id,
           author_id,
           category,
+          partner_id,
           logo_url,
           banner_url,
           modpack_versions (
@@ -1196,19 +1192,9 @@ export class ModpackManagementService {
 
       console.log('✅ User data found:', userData.id, 'Role:', userData.role, 'Partner:', userData.partner_id);
 
-      // Get author's partner_id if they're a partner (to check if same partner)
-      let authorPartnerId: string | null = null;
-      if (modpack.category === 'partner') {
-        const { data: authorData, error: authorError } = await supabase
-          .from('users')
-          .select('partner_id')
-          .eq('id', modpack.author_id)
-          .single() as { data: any; error: any };
-
-        if (!authorError && authorData) {
-          authorPartnerId = authorData.partner_id;
-        }
-      }
+      // partner_id is now sourced from modpacks.partner_id directly (set when modpack was created).
+      // Avoids cross-user read of users.partner_id which RLS no longer permits.
+      const authorPartnerId: string | null = modpack.category === 'partner' ? (modpack.partner_id ?? null) : null;
 
       // Check permissions:
       // - Owner can always delete their modpack

--- a/src/utils/__tests__/knownErrors.test.ts
+++ b/src/utils/__tests__/knownErrors.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { matchKnownError } from '../knownErrors';
+
+describe('matchKnownError', () => {
+  it('returns null for empty input', () => {
+    expect(matchKnownError('')).toBeNull();
+  });
+
+  it('matches eocd / corrupted zip patterns case-insensitively', () => {
+    const e = matchKnownError('Error: Could not find EOCD signature');
+    expect(e?.id).toBe('eocd');
+    expect(e?.canRetry).toBe(true);
+    expect(e?.isAutoRetryable).toBe(true);
+  });
+
+  it('matches os_error_32 pattern', () => {
+    const e = matchKnownError('failed: os error 32');
+    expect(e?.id).toBe('os_error_32');
+    expect(e?.isAutoRetryable).toBe(false);
+  });
+
+  it('matches decoding_response pattern', () => {
+    const e = matchKnownError('Error decoding response from server');
+    expect(e?.id).toBe('decoding_response');
+  });
+
+  it('matches mojang_connection pattern via regex', () => {
+    const e = matchKnownError('failed to connect to piston-meta.mojang.com');
+    expect(e?.id).toBe('mojang_connection');
+  });
+
+  it('returns null for unknown errors', () => {
+    expect(matchKnownError('completely unrelated bug 42')).toBeNull();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,33 @@ export default defineConfig(async () => ({
     emptyOutDir: false,
     // Increase chunk size warning limit for desktop app (2MB - acceptable for desktop)
     chunkSizeWarningLimit: 2000,
+    rollupOptions: {
+      output: {
+        // Split heavy deps into separate chunks for better caching + smaller initial JS
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'supabase': ['@supabase/supabase-js'],
+          'tauri': [
+            '@tauri-apps/api',
+            '@tauri-apps/plugin-fs',
+            '@tauri-apps/plugin-dialog',
+            '@tauri-apps/plugin-http',
+            '@tauri-apps/plugin-shell',
+            '@tauri-apps/plugin-process',
+            '@tauri-apps/plugin-opener',
+            '@tauri-apps/plugin-updater',
+          ],
+          'i18n': [
+            'i18next',
+            'react-i18next',
+            'i18next-browser-languagedetector',
+            'i18next-http-backend',
+          ],
+          'jszip': ['jszip'],
+          'icons': ['lucide-react', 'react-icons'],
+        },
+      },
+    },
   },
 
   // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`


### PR DESCRIPTION
## Summary

Comprehensive audit fixes across frontend (React/Tauri) and Rust backend. Companion backend PR: https://github.com/LuminaKraft/LuminaKraftLauncher-Backend/pulls

**Highlights:**
- Frontend perf: AnimationContext memoization, React.lazy on 7 non-home routes + Suspense, Vite manualChunks, Sidebar memo + once-only update check, ModpackCard memoized style, lazy locales target.
- Rust robustness: bound infinite retry loops (Minecraft install 20, Modrinth hash 5), atomic instance.json write (.tmp+rename), zip-slip starts_with guard, sanitize modpack_id (path traversal), recover poisoned RUNNING_PROCS mutex, guard double-launch, extract_zip wrapped in spawn_blocking, HMAC integrity doc note, drop unused md5 dep.
- Batch IPC: new `get_all_instance_metadata` Tauri command + parallel Promise.all in loadModpackStates (eliminates N round-trip storm).
- Frontend adaptation to tightened RLS: launcherService reads `users_public` view; modpackManagementService uses `modpacks.partner_id` directly instead of cross-user `users.partner_id` lookups.
- Tests: +27 vitest tests (authService, launcherService, knownErrors), +9 cargo tests (integrity sign/verify, modpack_id validator). Now: 39 vitest + 9 cargo green.
- CI: new `.github/workflows/test.yml` (lint + vitest + cargo check/clippy/test) on push/PR.
- Docs: CLAUDE.md pre-commit checklist + commit conventions (no AI credits).

Backend changes (separate PR):
- Migration 005 applied to prod (search_path on every SECURITY DEFINER fn, RLS privacy on users + modpack_stats, modpacks_i18n custom_protected_paths, anti-bypass anon downloads, bulk stats RPC).
- Edge functions hardened: sync-discord-roles derives userId from JWT (was caller-controlled, fixed cross-user escalation), curseforge-proxy requires auth + endpoint regex validation, delete-modpack-files blocks caller-supplied filePaths when modpack missing, get-r2-presigned-url sanitizes filename, CORS Allow-Credentials no longer paired with wildcard.

## Test plan
- [x] `npm run lint` 0 warnings
- [x] `npm run test` 39/39
- [x] `cargo check` clean
- [x] `cargo test` 9/9
- [x] Manual smoke: login Discord, list community modpacks (author names render via users_public), install + launch modpack
- [x] CI green on this PR after push